### PR TITLE
Fix ctags --extra option

### DIFF
--- a/resources/ctagOptions
+++ b/resources/ctagOptions
@@ -19,5 +19,5 @@
 --exclude=Builds
 --exclude=doc
 --fields=Knz
---extra=+f
+--extras=+f
 --append=no


### PR DESCRIPTION
Fixes the warning of obsolete `--extra` option and replace it with `--extras`
```
----------Generating Tags----------
ctags --options=$HOME/.config/coc/extensions/node_modules/coc-python/resources/ctagOptions --languages=Python --exclude=**/site-packages/** -o tags .
ctags: Warning: --extra option is obsolete; use --extras instead
```