### PR TITLE
删除source activatePath 配置

### DIFF
--- a/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -11,6 +11,7 @@ import { IPlatformService } from '../../platform/types'
 import { IConfigurationService } from '../../types'
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types'
 import { fileToCommandArgument, toCommandArgument } from '../../string'
+import { ITerminalActivator, ITerminalHelper, TerminalShellType } from '../types'
 
 // Version number of conda that requires we call activate with 'conda activate' instead of just 'activate'
 const CondaRequiredMajor = 4
@@ -26,6 +27,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
     @inject(IPlatformService) private platform: IPlatformService,
     @inject(IConfigurationService) private configService: IConfigurationService
   ) { }
+  constructor(private readonly helper: ITerminalHelper) { }
 
   /**
    * Is the given shell supported for activating a conda env?
@@ -62,7 +64,8 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
       const interpreterPath = await this.condaService.getCondaFileFromInterpreter(pythonPath, envInfo.name)
       if (interpreterPath) {
         const activatePath = fileToCommandArgument(path.join(path.dirname(interpreterPath), 'activate'))
-        if (_targetShell === TerminalShellType.fish) {
+        const shell = this.helper.identifyTerminalShell(this.helper.getTerminalShellPath())
+        if (shell === TerminalShellType.fish) {
           const firstActivate = this.platform.isWindows ? activatePath : ``
         } else {
           const firstActivate = this.platform.isWindows ? activatePath : `source ${activatePath}`

--- a/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -64,7 +64,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         const activatePath = fileToCommandArgument(path.join(path.dirname(interpreterPath), 'activate'))
         const firstActivate = this.platform.isWindows ?
           activatePath :
-          `source ${activatePath}`
+          ``
         return [
           firstActivate,
           `conda activate ${toCommandArgument(envInfo.name)}`

--- a/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -9,9 +9,8 @@ import { Uri } from 'coc.nvim'
 import { ICondaService } from '../../../interpreter/contracts'
 import { IPlatformService } from '../../platform/types'
 import { IConfigurationService } from '../../types'
-import { ITerminalActivationCommandProvider, TerminalShellType } from '../types'
+import { ITerminalActivationCommandProvider, ITerminalHelper, TerminalShellType } from '../types'
 import { fileToCommandArgument, toCommandArgument } from '../../string'
-import { ITerminalActivator, ITerminalHelper, TerminalShellType } from '../types'
 
 // Version number of conda that requires we call activate with 'conda activate' instead of just 'activate'
 const CondaRequiredMajor = 4

--- a/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -62,13 +62,12 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
       const interpreterPath = await this.condaService.getCondaFileFromInterpreter(pythonPath, envInfo.name)
       if (interpreterPath) {
         const activatePath = fileToCommandArgument(path.join(path.dirname(interpreterPath), 'activate'))
-        const firstActivate = this.platform.isWindows ?
-          activatePath :
-          ``
-        return [
-          firstActivate,
-          `conda activate ${toCommandArgument(envInfo.name)}`
-        ]
+        if (_targetShell === TerminalShellType.fish) {
+          const firstActivate = this.platform.isWindows ? activatePath : ``
+        } else {
+          const firstActivate = this.platform.isWindows ? activatePath : `source ${activatePath}`
+        }
+        return [ firstActivate, `conda activate ${toCommandArgument(envInfo.name)}` ]
       }
     }
 


### PR DESCRIPTION
对于大部分用户。conda命令 的环境变量已经在shell 里面，这步可以跳过。这样就可以支持更多的shell，比如fish shell等等