### PR TITLE
MACOS 现在默认的shell 是zsh

### DIFF
--- a/src/interpreter/activation/service.ts
+++ b/src/interpreter/activation/service.ts
@@ -28,7 +28,7 @@ const getEnvironmentTimeout = 30000
 // The shell under which we'll execute activation scripts.
 const defaultShells = {
   [OSType.Windows]: 'cmd',
-  [OSType.OSX]: 'bash',
+  [OSType.OSX]: 'zsh',
   [OSType.Linux]: 'bash',
   [OSType.Unknown]: undefined
 }


### PR DESCRIPTION
如果还是设置为bash 的话，会执行错误。导致执行卡30秒