### PR TITLE
fixes jedi.Script according to jedi release v.0.17.0

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -571,7 +571,8 @@ class JediCompletion(object):
         script = jedi.Script(
             source=request.get('source', None), line=request['line'] + 1,
             column=request['column'], path=request.get('path', ''),
-            sys_path=sys.path, environment=self.environment)
+            project=jedi.Project(request.get('path', ''), sys_path=sys.path),
+            environment=self.environment)
 
         if lookup == 'definitions':
             defs = self._get_definitionsx(script.goto_assignments(follow_imports=True), request['id'])


### PR DESCRIPTION
According to jedi v.0.17.0 the sys_path argument should be replaced by project=Project(dir, sys_path=sys_path))