### PR TITLE
Allow changing the path to the language server binary

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,7 @@ Except from `test`, `debug` and `datascience` features of [vscode-python](https:
 - `python.autoComplete.showAdvancedMembers`:Controls appearance of methods with double underscores in the completion list., default: `true`
 - `python.autoComplete.typeshedPaths`:Specifies paths to local typeshed repository clone(s) for the Python language server., default: `[]`
 - `python.autoUpdateLanguageServer`:Automatically update the language server., default: `true`
+- `python.languageServerPath`:If not empty, use the provided language server binary instead of the one that's been downloaded., default: `""`
 - `python.disableInstallationCheck`:Whether to check if Python is installed (also warn when using the macOS-installed Python)., default: `false`
 - `python.envFile`:Absolute path to a file containing environment variable definitions., default: `"${workspaceFolder}/.env"`
 - `python.trace.server`:Trace level of tsserver, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -181,6 +181,12 @@
           "description": "Automatically update the language server.",
           "scope": "application"
         },
+        "python.languageServerPath": {
+            "type": "string",
+            "description": "Overrides the auto-installed Python Language server binary path.",
+            "default": "",
+            "scope": "resource"
+        },
         "python.disableInstallationCheck": {
           "type": "boolean",
           "default": false,

--- a/src/activation/languageServer/languageClientFactory.ts
+++ b/src/activation/languageServer/languageClientFactory.ts
@@ -49,12 +49,16 @@ export class BaseLanguageClientFactory implements ILanguageClientFactory {
 @injectable()
 export class DownloadedLanguageClientFactory implements ILanguageClientFactory {
   constructor(@inject(IPlatformData) private readonly platformData: IPlatformData,
+    @inject(IConfigurationService) private readonly configurationService: IConfigurationService,
     @inject(ILanguageServerFolderService) private readonly languageServerFolderService: ILanguageServerFolderService,
     @inject(IExtensionContext) private readonly context: IExtensionContext) { }
 
   public async createLanguageClient(_resource: Resource, clientOptions: LanguageClientOptions, env?: NodeJS.ProcessEnv): Promise<LanguageClient> {
+    let serverModule = this.configurationService.getSettings().languageServerPath;
     const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName()
-    const serverModule = path.join(this.context.storagePath, languageServerFolder, this.platformData.engineExecutableName)
+    if(serverModule === "") {
+        serverModule = path.join(this.context.storagePath, languageServerFolder, this.platformData.engineExecutableName)
+    }
     const serverOptions: Executable = {
       command: serverModule,
       args: [],

--- a/src/common/configSettings.ts
+++ b/src/common/configSettings.ts
@@ -42,6 +42,7 @@ export class PythonSettings implements IPythonSettings {
   public globalModuleInstallation = false
   public analysis!: IAnalysisSettings
   public autoUpdateLanguageServer = true
+  public languageServerPath = ""
   public datascience!: IDataScienceSettings
 
   protected readonly changed = new Emitter<void>()
@@ -147,6 +148,8 @@ export class PythonSettings implements IPythonSettings {
     this.downloadLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('downloadLanguageServer', true))!
     this.jediEnabled = systemVariables.resolveAny(pythonSettings.get<boolean>('jediEnabled', true))!
     this.autoUpdateLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('autoUpdateLanguageServer', true))!
+    this.languageServerPath = systemVariables.resolveAny(pythonSettings.get<string>('languageServerPath', ''))!
+
     if (this.jediEnabled) {
       // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
       this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -163,6 +163,7 @@ export interface IPythonSettings {
   readonly globalModuleInstallation: boolean
   readonly analysis: IAnalysisSettings
   readonly autoUpdateLanguageServer: boolean
+  readonly languageServerPath: string
   readonly datascience: IDataScienceSettings
   readonly onDidChange: Event<void>
 }


### PR DESCRIPTION
Some users might want to use a different Python language server binary
than the one automatically downloaded by the extension. For example, on
some distributions of Linux, the official binaries do not work, and a
patched version is needed. It can be installed from the repositories,
and this patch allows the user to force coc-python to use it.

This is accomplished by adding a setting `python.languageServerPath`,
which, if non-empty, is used as the language server binary path instead
of the one downloaded by the extension.

So, for example you can set it to `/usr/bin/python-language-server`, or anything else.