### PR TITLE
Feed isort from stdin (#225)

### DIFF
--- a/src/common/process/proc.ts
+++ b/src/common/process/proc.ts
@@ -89,10 +89,14 @@ export class ProcessService implements IProcessService {
       }
     }
   }
-  public exec(file: string, args: string[], options: SpawnOptions = {}): Promise<ExecutionResult<string>> {
+  public exec(file: string, args: string[], options: SpawnOptions = {}, stdinContent: string = ""): Promise<ExecutionResult<string>> {
     const spawnOptions = this.getDefaultOptions(options)
     const encoding = spawnOptions.encoding ? spawnOptions.encoding : 'utf8'
+
     const proc = spawn(file, args, spawnOptions)
+    proc.stdin.write(stdinContent)
+    proc.stdin.end()
+
     const deferred = createDeferred<ExecutionResult<string>>()
 
     if (options.token) {

--- a/src/common/process/pythonProcess.ts
+++ b/src/common/process/pythonProcess.ts
@@ -72,9 +72,9 @@ export class PythonExecutionService implements IPythonExecutionService {
     const opts: SpawnOptions = { ...options }
     return this.procService.execObservable(this.pythonPath, ['-m', moduleName, ...args], opts)
   }
-  public async exec(args: string[], options: SpawnOptions): Promise<ExecutionResult<string>> {
+  public async exec(args: string[], options: SpawnOptions, stdinContent?: string): Promise<ExecutionResult<string>> {
     const opts: SpawnOptions = { ...options }
-    return this.procService.exec(this.pythonPath, args, opts)
+    return this.procService.exec(this.pythonPath, args, opts, stdinContent)
   }
   public async execModule(moduleName: string, args: string[], options: SpawnOptions): Promise<ExecutionResult<string>> {
     const opts: SpawnOptions = { ...options }

--- a/src/common/process/types.ts
+++ b/src/common/process/types.ts
@@ -43,7 +43,7 @@ export interface ExecutionResult<T extends string | Buffer> {
 
 export interface IProcessService {
   execObservable(file: string, args: string[], options?: SpawnOptions): ObservableExecutionResult<string>
-  exec(file: string, args: string[], options?: SpawnOptions): Promise<ExecutionResult<string>>
+  exec(file: string, args: string[], options?: SpawnOptions, stdinContent?: string): Promise<ExecutionResult<string>>
   shellExec(command: string, options?: ShellOptions): Promise<ExecutionResult<string>>
 }
 
@@ -87,7 +87,7 @@ export interface IPythonExecutionService {
   execObservable(args: string[], options: SpawnOptions): ObservableExecutionResult<string>
   execModuleObservable(moduleName: string, args: string[], options: SpawnOptions): ObservableExecutionResult<string>
 
-  exec(args: string[], options: SpawnOptions): Promise<ExecutionResult<string>>
+  exec(args: string[], options: SpawnOptions, stdinContent?: string): Promise<ExecutionResult<string>>
   execModule(moduleName: string, args: string[], options: SpawnOptions): Promise<ExecutionResult<string>>
 }
 


### PR DESCRIPTION
With this PR `isort` will be fed the current buffer content from stdin.
Previously, when runnign `isort` the file content would be read from disc,
meaning that running it on a dirty buffer would break the edited file, since the
diff generated by `isort` would not match the file. 
In the same fashion, running `isort` multiple times would also break the file.

By always feeding the current buffer content to `isort`, you get wysiwyg behavior.

**This PR requires isort to be of version 5.5.2**
**For reference see: https://github.com/PyCQA/isort/issues/1469**

Closes https://github.com/neoclide/coc-python/issues/225