### PR TITLE
fix class def snippets

### DIFF
--- a/snippets/python.json
+++ b/snippets/python.json
@@ -143,16 +143,16 @@
         ],
         "description": "Code snippet for a function definition"
     },
-    "def(class method)": {
-        "prefix": "def(class method)",
+    "def/class_method": {
+        "prefix": "def/class_method",
         "body": [
             "def ${1:funcname}(self, ${2:parameter_list}):",
             "\t${3:pass}"
         ],
         "description": "Code snippet for a class method"
     },
-    "def(static class method)": {
-        "prefix": "def(static class method)",
+    "def/static_class_method": {
+        "prefix": "def/static_class_method",
         "body": [
             "@staticmethod",
             "def ${1:funcname}(${2:parameter_list}):",
@@ -160,8 +160,8 @@
         ],
         "description": "Code snippet for a static class method"
     },
-    "def(abstract class method)": {
-        "prefix": "def(abstract class method)",
+    "def/abstract_class_method": {
+        "prefix": "def/abstract_class_method",
         "body": [
             "def ${1:funcname}(self, ${2:parameter_list}):",
             "\traise NotImplementedError"


### PR DESCRIPTION
NVIM v0.5.0-812-gd17e50879
coc-python 1.2.13

Snippets don't expand as expected.

Behavior before fix:
![image](https://user-images.githubusercontent.com/16717904/102955919-f1e4db00-4511-11eb-8bbe-4e1085209824.png)

Behavior after fix:
![image](https://user-images.githubusercontent.com/16717904/102955950-1345c700-4512-11eb-9e68-61524ad95e9d.png)
